### PR TITLE
do not use autoReconnect feature if a replica set or sharded cluster …

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = {
 
       // If a comma separated host list appears, or a mongodb+srv seedlist URI,
       // it's a replica set or sharded cluster. In either case, the autoReconnect
-      // eature is undesirable and will actually cause problems, per the MongoDB
+      // feature is undesirable and will actually cause problems, per the MongoDB
       // team:
       //
       // https://github.com/apostrophecms/apostrophe/issues/1508

--- a/index.js
+++ b/index.js
@@ -67,13 +67,13 @@ module.exports = {
       }
 
       // If a comma separated host list appears, or a mongodb+srv seedlist URI,
-      // it's a replica set or sharded cluster. In either case, the autoReconnect 
+      // it's a replica set or sharded cluster. In either case, the autoReconnect
       // eature is undesirable and will actually cause problems, per the MongoDB
       // team:
       //
       // https://github.com/apostrophecms/apostrophe/issues/1508
 
-      if (uri.match(/\/\/.*?\,.*?\//) || uri.match(/^mongodb\+srv/)) {
+      if (uri.match(/\/\/[^/]+,/) || uri.match(/^mongodb\+srv/)) {
         delete baseOptions.autoReconnect;
         delete baseOptions.reconnectTries;
         delete baseOptions.reconnectInterval;


### PR DESCRIPTION
…is present, per MongoDB team

See https://github.com/apostrophecms/apostrophe/issues/1508 for discussion with Matt Broadstone ( @mbroadst ) from the MongoDB team.

For bc, we continue to use autoReconnect by default, however if the mongodb URI contains a comma in the hostname portion or is a mongodb+srv URI, we know the client will implement its built-in server selection behavior. autoReconnect just breaks that by forcing reconnection to the same node that just failed, which might never come back.

So in the presence of either the comma or the mongodb+srv protocol, we clear the parameters intended for autoReconnect. Nothing else changes here.

See also corresponding PR to the Apostrophe module itself for cases where a replica set connection is being used with the older 2.x MongoDB driver.